### PR TITLE
fix: better handling of Accept headers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
   ],
   "rules": {
     "no-console": "off",
+    "import/prefer-default-export": "off",
     "no-restricted-syntax": [
         "error",
         {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018-2021 BOTLabs GmbH.
+ *
+ * This source code is licensed under the BSD 4-Clause "Original" license
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+function processAcceptHeaders(headers) {
+    const acceptedTypes = new Set([...headers.split(',').map((c) => c.trim())])
+    let exportType
+    let defaultExport
+    let responseContentType
+    if (acceptedTypes.has('application/did+json')) {
+        exportType = 'application/json'
+        defaultExport = {}
+        responseContentType = 'application/did+json'
+    } else {
+        exportType = 'application/ld+json'
+        defaultExport = { '@context': ['https://www.w3.org/ns/did/v1'] }
+        responseContentType = 'application/did+ld+json'
+    }
+    return {
+        exportType,
+        defaultExport,
+        responseContentType
+    }
+}
+
+module.exports = { processAcceptHeaders }


### PR DESCRIPTION
When we run behind the DIF proxy, we always get an `application/ld+json;profile=https://w3id.org/did-resolution` Accept header, so we could theoretically return always a JSON+LD document. Nevertheless, there are also cases where we might have an additional `application/did+json` input, in which case we now return a simple JSON document, with no `@context information`.
The DIF proxy then takes care of properly formatting output according to the accepted mimetypes.

## Limitations

Apparently it is not possible in an express application to get the fragment part of a URL, i.e., everything after `#`, so this means that we can't know if the user is trying to resolve a fragment or the whole DID. Nevertheless, I think the way we handle it is not against the standard and is acceptable, so I would suggest we open a PR like this, and see if they have any comments about this or anything else.