### PR TITLE
fix: replace named request param to wildcard matcher

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -6,7 +6,7 @@
  */
 
 // did
-const URI_DID = '/1.0/identifiers/:did'
+const URI_DID = '/1.0/identifiers/*'
 
 module.exports = {
   URI_DID

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,8 @@ async function start() {
       console.info('\n→ Received headers:')
       console.info(JSON.stringify(req.headers, null, 2))
       const { exportType, defaultExport, responseContentType } = processAcceptHeaders(req.headers.accept)
-      const { did } = req.params
+      // We can't use pattern matching as the DID might include '/' characters.
+      const did = req.params['0']
       // Add queried DID to default export for deleted resolutions
       defaultExport.id = did
 


### PR DESCRIPTION
Base64-encoding includes the `/` character in its charset, which creates issues with the driver, as it cuts off the input DID to the first occurrence of '/'.
This PR fixes that by replacing

```javascript
const URI_DID = '/1.0/identifiers/:did'
```

with 

```javascript
const URI_DID = '/1.0/identifiers/*'
```