### PR TITLE
feat: smaller builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN yarn install
+RUN yarn install --production
 
 # From https://github.com/nodejs/docker-node/issues/282#issue-193774074 (same as above)
 RUN apk del .gyp


### PR DESCRIPTION
We can shrink the size of our docker images a bit if we only install core dependencies, excluding dev dependencies. Shaves off about 50 MB, 10% of the image size. What do you think, @Diiaablo95 ?
