### PR TITLE
feat: handle runtime upgrades gracefully

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,15 @@ async function start() {
   await init({ address: BLOCKCHAIN_NODE })
   const { api } = await connect()
 
-  const hasWeb3Names = !!api.consts.web3Names
+  const hasWeb3Names = () => !!api.consts.web3Names
+  const logWeb3NameSupport = () => {
+    console.info(
+      hasWeb3Names()
+        ? '🥳 Web3Names are available on this chain!'
+        : '👵 Web3Names are currently not available on this chain'
+    )
+  }
+  api.on('decorated', logWeb3NameSupport)
 
   // URI_DID is imposed by the universal-resolver
   driver.get(URI_DID, async (req, res) => {
@@ -90,7 +98,7 @@ async function start() {
           )
 
           if (
-            hasWeb3Names &&
+            hasWeb3Names() &&
             resolvedDidDetails.details instanceof Did.FullDidDetails
           ) {
             // check for web3name
@@ -146,11 +154,7 @@ async function start() {
     console.info(
       `🚀 KILT DID resolver driver running on port ${PORT} and connected to ${BLOCKCHAIN_NODE}...`
     )
-    console.info(
-      hasWeb3Names
-        ? '\n🥳 Web3Names are available on this chain!'
-        : '\n👵 Web3Names are not available on this chain'
-    )
+    logWeb3NameSupport()
   })
 }
 


### PR DESCRIPTION
## Solution B)

closes #30

The polkadot api already monitors runtime upgrades and re-decorates automatically. Thus we just need to make sure we recheck the availability of the Web3Name functionality whenever required. Simpler solution compared to #30 

## How to test:

A simple tests consists in running the driver against a local test node on version 1.4.0, then shutting down the node and replacing it with one running version 1.5.0.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
