### PR TITLE
chore: use node v20

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/Iron

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:20-alpine
 # Some tools required when using alpine -> https://github.com/nodejs/docker-node/issues/282#issue-193774074
 RUN apk add --no-cache --virtual .gyp python3 make g++
 


### PR DESCRIPTION
The polkadot dependencies we updated to are no longer accepting node 16