### PR TITLE
feat: graceful shutdown

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,8 +11,11 @@ require('../envConfig')
 const BLOCKCHAIN_NODE = process.env.KILT_BLOCKCHAIN_NODE
 // server port
 const PORT = 8080
+// grace period in ms
+const SHUTDOWN_GRACE_PERIOD = 5000
 
 module.exports = Object.freeze({
   BLOCKCHAIN_NODE,
-  PORT
+  PORT,
+  SHUTDOWN_GRACE_PERIOD
 })

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const {
   W3C_DID_CONTEXT_URL,
   KILT_DID_CONTEXT_URL
 } = require('@kiltprotocol/did')
-const { PORT, BLOCKCHAIN_NODE } = require('./config')
+const { PORT, BLOCKCHAIN_NODE, SHUTDOWN_GRACE_PERIOD } = require('./config')
 const {
   URI_DID,
   DID_RESOLUTION_RESPONSE_MIME,
@@ -150,10 +150,12 @@ async function start() {
     console.log(`${signal} signal received: closing HTTP server`)
     const timeout = setTimeout(() => {
       console.warn(
-        'timeout for pending requests, force-closing open connections'
+        `timeout for pending requests after ${
+          SHUTDOWN_GRACE_PERIOD / 1000
+        }s, force-closing open connections`
       )
       server.closeAllConnections()
-    }, 5000).unref()
+    }, SHUTDOWN_GRACE_PERIOD).unref()
     server.close(() => {
       clearTimeout(timeout)
       console.log('HTTP server closed, closing api connection')

--- a/src/index.js
+++ b/src/index.js
@@ -146,13 +146,18 @@ async function start() {
   })
 
   // graceful shutdown: stop accepting new requests -> wait for running requests to be completed -> close api connection and exit
+  function shutdown(signal) {
+    console.log(`${signal} signal received: closing HTTP server`)
   process.on('SIGTERM', () => {
     console.log('SIGTERM signal received: closing HTTP server')
     server.close(() => {
       console.log('HTTP server closed, closing api connection')
       api.disconnect().then(() => console.log('api connection closed'))
     })
-  })
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+  process.on('SIGQUIT', shutdown)
 }
 
 start()

--- a/src/index.js
+++ b/src/index.js
@@ -148,9 +148,14 @@ async function start() {
   // graceful shutdown: stop accepting new requests -> wait for running requests to be completed -> close api connection and exit
   function shutdown(signal) {
     console.log(`${signal} signal received: closing HTTP server`)
-  process.on('SIGTERM', () => {
-    console.log('SIGTERM signal received: closing HTTP server')
+    const timeout = setTimeout(() => {
+      console.warn(
+        'timeout for pending requests, force-closing open connections'
+      )
+      server.closeAllConnections()
+    }, 5000).unref()
     server.close(() => {
+      clearTimeout(timeout)
       console.log('HTTP server closed, closing api connection')
       api.disconnect().then(() => console.log('api connection closed'))
     })


### PR DESCRIPTION
Came across this in the express docs, and indeed, this gives a much smoother shutdown of the driver when running in a docker container.
While it was always forcefully exited before after 10s of not responding to SIGTERM, we get a nice shutdown with this after disconnecting the api. 

## How to test:

Run in a docker container with `docker compose up --build`, then use `docker compose down` to remove and watch the shutdown times.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
