### PR TITLE
chore: bump type definitions to peregrine release

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
     "eslint-plugin-prettier": "^3.1.0",
     "husky": "^4.2.3",
     "prettier": "^2.0.5"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "resolutions": {
+    "@kiltprotocol/type-definitions": "1.11501.0-peregrine"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,10 +418,10 @@
     "@polkadot/util-crypto" "^13.0.2"
     "@scure/base" "^1.1.1"
 
-"@kiltprotocol/type-definitions@^1.11200.0":
-  version "1.11200.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/type-definitions/-/type-definitions-1.11200.0.tgz#58f6dd9ae09925d6f46189f6b1ecef78b38cdd24"
-  integrity sha512-S99koF1rLqPyOkOTcs+6mWm/HOPxfSipd1F8A77SdNyum1mKT0Vc0bqZzfIBCJdOHV4r2foEZlTRT7JA1WjEuA==
+"@kiltprotocol/type-definitions@1.11501.0-peregrine", "@kiltprotocol/type-definitions@^1.11200.0":
+  version "1.11501.0-peregrine"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/type-definitions/-/type-definitions-1.11501.0-peregrine.tgz#d2a6d0c9d6b10f795421154259f420d722a66403"
+  integrity sha512-ZjO2lnlppdECH5Ix5FDrQvxMlqvr9wPtYfiNQ9sb7pn6dslSY6xlBwKMl0BlokdyIE4HGVLI0AiDz6av/MloAA==
 
 "@kiltprotocol/types@0.100.0":
   version "0.100.0"


### PR DESCRIPTION
## fixes KILTProtocol/ticket#3771

Bumps the type-definitions so that did runtime apis become available again on peregrine.

## How to test:

In the `.env` file, set the ws endpoint to the peregrine node, then run
```
docker compose pull
docker compose up --build
```

You can now access the web interface on `http://localhost:7081/` and start resolving peregrine DIDs.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
